### PR TITLE
Add Stale[bot] configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - emergency
+  - high priority
+  - priority
+  - security
+
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Uses https://probot.github.io/apps/stale/ to mark inactive issues as `wontfix` after 60 days unless someone comments to keep the issue open in 7 days after the `wontfix` label is added. 

The bot will never mark `emergency`, `high priority`, `priority`, or `security` labeled issues as `wontfix`. 