### PR TITLE
More gentle stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,15 +1,19 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 90
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 10
 
 # Issues with these labels will never be considered stale
 exemptLabels:
+  - backlog
+  - bug
   - emergency
   - high priority
   - priority
+  - project
   - security
+  - technical-debt
 
 # Label to use when marking an issue as stale
 staleLabel: stale


### PR DESCRIPTION
- Increase daysUntilState to 90
- Increase daysUntilClose to 10
- Don't run on the following labels:
  - backlog: These are tasks that are programmed to do.
  - bug: We should not let bugs unfixed.
  - project: These are meta-tasks of things we need to do. Thay may not be active for a long period, but we still need to keep them
  - technical-debt: We should not forget about these