### PR TITLE
Remove close message from stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -21,8 +21,10 @@ staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity. We want to keep it in our todo list but haven't had the time
+  to address it yet.
+  
+  Thank you for your contributions!
 
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
The message were saying that issue will be closed if no activity but we don't do that anymore