### PR TITLE
IssuesTemplates: Add section about prioritization to Project

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.md
+++ b/.github/ISSUE_TEMPLATE/project.md
@@ -15,6 +15,24 @@ assignees: ''
 
 *Note: Project owner responsibilities include coordinating all the different people that need to contribute to the project, defining specs and goals, communicating project progress, being the point person for decisions, QA, documentation, and a plan for ongoing maintenance. If the project owner can't continue, they need to hand the role over to another person explicitly.*
 
+## Prioritization
+
+<!-- Please fill out the following questions to rationalize the prioritization of this project -->
+
+- Does this serve our mission?
+
+- Will this help to make us financially sustainable within a year?
+
+- Is it feasible to build and maintain with our team and runway?
+
+- Can this make us move faster?
+
+- Does this increase quality and not technical debt?
+
+- Will this bring us more Collective and financial contributors?
+
+- Is this already solved elsewhere or is it our unique contribution?
+
 ## Roadmap & Timeframe
 (Key milestones or phases and estimated delivery dates, including specs, design, feature development, feedback, marketing/comms, and documentation)
 


### PR DESCRIPTION
During the last team retreat we have defined a framework for prioritization. This pull request adds it to the `Project` issue template to enforce its usage.

Based on https://docs.opencollective.com/help/product/roadmap#key-questions-for-prioritization