### PR TITLE
Try to make stalebot message clearer

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -20,11 +20,8 @@ staleLabel: stale
 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. We want to keep it in our todo list but haven't had the time
-  to address it yet.
-  
-  Thank you for your contributions!
+  This issue has been automatically marked as stale because it has not had recent activity.
+  We haven't had the time to address it yet, but **we want to keep it open**. This message is just a reminder for us to help triage issues.
 
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
Often people misunderstand that our stale bot is not going to close issues. One of the reasons may be that they're used to stale bots doing it (that's the default behavior). Anyway I thought we could try to make that clear and I'd be happy to hear suggestions if anyone has a better idea.  

New message:

>   This issue has been automatically marked as stale because it has not had recent activity.
  We haven't had the time to address it yet, but **we want to keep it open**. This message is just a reminder for us to help triage issues.