### PR TITLE
Add documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -17,7 +17,7 @@ assignees: ''
 <!-- Help us understand why we're making this change, what is it going to help users achieve? -->
 
 ### Who does this change impact?
-<!-- Which groups of users are going to impacted by this change: contributors, collective admins, hosts, all? -->
+<!-- Which groups of users are going to be impacted by this change: contributors, collective admins, hosts, all? -->
 
 ### How do users use it?
 <!-- How are users going to interact with the platform in order to achieve the goals we set out? --> 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -38,7 +38,7 @@ assignees: ''
 <!-- Use this section to provide an overview of the changes that we think we'll need to make. -->
 
 ### Changes to be made
-<!-- Use this section to outline, at a hgih level, which pages will need to be added, modified, removed etc -->
+<!-- Use this section to outline, at a high level, which pages will need to be added, modified, removed etc -->
 
 ### Estimate of effort
 <!-- How long do we think it will take to make those changes, how long after completing the development do we think we'll need to ensure docs are ready to go for lauch? -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,44 @@
+---
+name: Documentation
+about: For project owners to kick off the project documentation process
+title: "[DOCS]"
+labels: 'documentation'
+assignees: ''
+
+---
+
+## Context
+<!-- Use this section to bring the documentation team up to speed with the project we're working on --> 
+
+### What's changing?
+<!-- Use this section to breifly describe the project: what is going to change on the platform as a result of this project and how might users be impacted? -->
+
+### Why are we changing it?
+<!-- Help us understand why we're making this change, what is it going to help users achieve? -->
+
+### Who does this change impact?
+<!-- Which groups of users are going to impacted by this change: contributors, collective admins, hosts, all? -->
+
+### How do users use it?
+<!-- How are users going to interact with the platform in order to achieve the goals we set out? --> 
+
+### Is this change optional or mandatory?
+<!-- Is this change configurable? If so how does a user configure or opt into or out of it? -->
+
+### Is this change being released incrementally as a beta? What's the schedule?
+<!-- is this change a beta, how can users give us feedback or report bugs, is there any specific feedback we're looking for? -->
+
+### When will the project be ready for release/complete?
+<!-- We need to understand when we need to have documentation prepped and ready to launch, there may be some conversation once the docs team have reviewed this -->
+
+## Docs Process
+<!-- The docs team will use this section to plan how the docs are going to change as a result of this project --> 
+
+### Overview
+<!-- Use this section to provide an overview of the changes that we think we'll need to make. -->
+
+### Changes to be made
+<!-- Use this section to outline, at a hgih level, which pages will need to be added, modified, removed etc -->
+
+### Estimate of effort
+<!-- How long do we think it will take to make those changes, how long after completing the development do we think we'll need to ensure docs are ready to go for lauch? -->


### PR DESCRIPTION
Adding a documentation issue template that can be used when we kick off a project to ensure that the docs team are involved in the process from the start.