### PR TITLE
Add Some Basic Maintainer Issue Reply Templates

### DIFF
--- a/.github/MAINTAINER_REPLY_TEMPLATES/DONT_COMMENT_ON_CLOSED_ISSUE.md
+++ b/.github/MAINTAINER_REPLY_TEMPLATES/DONT_COMMENT_ON_CLOSED_ISSUE.md
@@ -1,0 +1,6 @@
+Please don't comment on already **closed issues**. If you think the issue is still there please feel free to
+[open a new issue](https://github.com/opencollective/opencollective/issues/new/choose) and refer this issue in the details. 
+
+Alternatively if you have a question, feel free to post in our [Slack channel](https://opencollective.slack.com/archives/C0HSLRNVC).
+If this is a support issue please email us at support@opencollective.com. More information can be found at, 
+https://docs.opencollective.com/help/internal/support.

--- a/.github/MAINTAINER_REPLY_TEMPLATES/GUIDELINES_NOT_FOLLOWED.md
+++ b/.github/MAINTAINER_REPLY_TEMPLATES/GUIDELINES_NOT_FOLLOWED.md
@@ -1,0 +1,7 @@
+This ticket is closed due to **guidelines not followed**. 
+
+All tickets should follow the guidelines as mentioned in: 
+
+- The [Code of Conduct](https://github.com/opencollective/opencollective/blob/main/CODE_OF_CONDUCT.md).
+
+- Submission guidelines as mentioned in our [README file](https://github.com/opencollective/opencollective/blob/main/README.md#issues).

--- a/.github/MAINTAINER_REPLY_TEMPLATES/README.md
+++ b/.github/MAINTAINER_REPLY_TEMPLATES/README.md
@@ -1,0 +1,9 @@
+# Reply templates for maintainers
+
+Here is a list of common **reply messages** shared by core team members to help them respond to issues.
+
+You can add those to your [GitHub saved replies settings](https://github.com/settings/replies).
+
+- [Guidelines are not followed](GUIDELINES_NOT_FOLLOWED.md)
+- [Use Slack](WRONG_FORUM_USE_SLACK.md)
+- [Don't comment on a closed issue](DONT_COMMENT_ON_CLOSED_ISSUE.md)

--- a/.github/MAINTAINER_REPLY_TEMPLATES/WRONG_FORUM_USE_SLACK.md
+++ b/.github/MAINTAINER_REPLY_TEMPLATES/WRONG_FORUM_USE_SLACK.md
@@ -1,0 +1,3 @@
+We use the issue tracker to only track **Bugs**, **Feature Requests**, **Documentation**, **Projects** and **Security Vulnerabilities**. 
+If you have a question please use our [Slack channel](https://opencollective.slack.com/archives/C0HSLRNVC). This will
+help to keep the issue tracker clean.

--- a/.github/MAINTAINER_REPLY_TEMPLATES/WRONG_FORUM_USE_SLACK.md
+++ b/.github/MAINTAINER_REPLY_TEMPLATES/WRONG_FORUM_USE_SLACK.md
@@ -1,3 +1,3 @@
-We use the issue tracker to only track **Bugs**, **Feature Requests**, **Documentation**, **Projects** and **Security Vulnerabilities**. 
+We use the issue tracker to only track **Bugs**, **Feature Requests**, **Documentation**, **Projects**. 
 If you have a question please use our [Slack channel](https://opencollective.slack.com/archives/C0HSLRNVC). This will
 help to keep the issue tracker clean.


### PR DESCRIPTION
As per my discussion started at https://github.com/opencollective/opencollective/discussions/4308 and https://github.com/opencollective/opencollective/issues/4304#issuecomment-846712621, I just quickly created this with some standard issue reply templates. We can probably add more or alter this later as needed. 😄 

Also this is just my opinion/way of doing this; if you disagree or think that the current system in place is sufficient for now it's fine to close this and we can incorporate this kinda process later as well. I am open to ideas or suggestions. 😄 