### PR TITLE
Fix GitHub typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Get paid to contribute to Open Source! The Open Collective engineering team is s
 This repository serves as [our main issue tracker](https://github.com/opencollective/opencollective/issues). When creating issues, it's important to follow common guidelines to make them extra clear. Here is a few links that we liked to help you achieve that:
 
 - [GitHub Guides: Mastering Issues](https://guides.github.com/features/issues/)
-- [Wiredcraft: How We Write Github Issues](https://wiredcraft.com/blog/how-we-write-our-github-issues/)
-- [NYC Planning Digital: Writing Useful Github Issues](https://medium.com/nyc-planning-digital/writing-a-proper-github-issue-97427d62a20f)
+- [Wiredcraft: How We Write GitHub Issues](https://wiredcraft.com/blog/how-we-write-our-github-issues/)
+- [NYC Planning Digital: Writing Useful GitHub Issues](https://medium.com/nyc-planning-digital/writing-a-proper-github-issue-97427d62a20f)
 
 ## Questions?
 

--- a/rfcs/005-replace-downshift-by-react-select.md
+++ b/rfcs/005-replace-downshift-by-react-select.md
@@ -22,7 +22,7 @@ By using a library to handle our selects, we can benefit from other rich feature
 
 # Solution
 
-I've used `react-select` in the past. It's a mature library (it went through major re-designs for v2 and V3) that is actually the more popular select library for react (almost 17.000 stars on Github). It uses the same patterns than `styled-component` for customization, so we'll be able to implement our design system easily.
+I've used `react-select` in the past. It's a mature library (it went through major re-designs for v2 and V3) that is actually the more popular select library for react (almost 17.000 stars on GitHub). It uses the same patterns than `styled-component` for customization, so we'll be able to implement our design system easily.
 
 In addition to everything you could expect from a select, it has the following features:
 

--- a/rfcs/009-move-away-from-react-hook-form.md
+++ b/rfcs/009-move-away-from-react-hook-form.md
@@ -33,7 +33,7 @@ main maintainer tends to show that we shouldn't expect from the library to cover
 Feature requests are [not tracked in an open way](https://github.com/react-hook-form/react-hook-form/issues/979#issuecomment-582843971) and issues are systematically closed without being implemented, which creates a
 lot of duplicates and uncertainty about wether or not issues will be addressed.
 
-A [Github project](https://github.com/react-hook-form/react-hook-form/projects/1)
+A [GitHub project](https://github.com/react-hook-form/react-hook-form/projects/1)
 supposedly addresses that, but it's only a bunch of cards with a short descriptions and it's unclear how
 things end up there (it may be somehow transparent, but it's not open).
 


### PR DESCRIPTION
This typo is also there when we hover our mouse to the GitHub icon in the website:

![image](https://user-images.githubusercontent.com/50847364/128790327-2154e291-1aef-42ee-8d2b-3e0f753256fa.png)