### PR TITLE
Edit project template

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.md
+++ b/.github/ISSUE_TEMPLATE/project.md
@@ -2,81 +2,130 @@
 name: Project
 about: For project owners in our core team to kick off new projects
 title: "[PROJECT]"
-labels: ''
+labels: 'project'
 assignees: ''
 
 ---
 
-## Overview
-(What is this project and why have we prioritised it?)
+## Overview 
+<!-- (What is the need, problem or challenge we are tackling? -->
 
-## Owner
-(Name of core team member responsible for the project)
+## Ownership
+<!-- Add yourself as owner here, discuss ownership with another iif needed -->
+**Owner:** 
+<!-- Add the following roles as they develop, again discuss ownership before @mentioning -->
+<!-- **Product:** -->
+<!-- **Design** -->
+<!-- **Engineering**  -->
+<!-- **Documentation**  -->
+<!-- **Documentation**  -->
 
 *Note: Project owner responsibilities include coordinating all the different people that need to contribute to the project, defining specs and goals, communicating project progress, being the point person for decisions, QA, documentation, and a plan for ongoing maintenance. If the project owner can't continue, they need to hand the role over to another person explicitly.*
 
-**Secondary Developer on project:** 
-
 ## Prioritization
+<!-- Why should we prioritize this project? -->
 
-<!-- Please fill out the following questions to rationalize the prioritization of this project -->
+**Impact**
+<!-- What is the perceived impact of this project? How condifent are we about this? -->
 
-- Does this serve our mission
+**Alignment**
+<!-- How well does this project align with our mission, our current goals and focus? -->
 
+**Effort**
+<!-- What's the perceived level of effort needed to complete this project? How confident are we about it?-->
+
+## Measuring success
+<!-- What do you expect to see as a result of this project? How will you measure it?-->
+
+## Next steps
+<!-- Is there further work needed to answer any of the questions above? How might we answer them? What support is needed (@mention anyone you would like to discuss this with) -->
+
+
+## Templates
+Feel free to use the following text as templates for further work on this issue:
+
+<details>
+<summary>Further Prioritisation </summary>
+<pre>
+- How does this serve our mission
 - Will this help to make us financially sustainable within a year?
-
 - Can this make us move faster?
-
 - Does this increase quality? 
-
 - Does this add technical debt?
-
 - Is it feasible to build and maintain with our current team and runway?
-
 - What insight or research is this project based on?
 - Is this problem already solved elsewhere?
-
 - How will we measure our success? Do we have a baseline today that we can compare this against?
-
 - How well do we understand the complexity of the problem, feature to be added or user need to be addressed? 
+- What is the estimated timeframe for delivering this project?
+</pre>
+</details>
 
-- What is the estimated timeframe for delivering this project? 
+<details>
+<summary>Roadmap</summary>
+<pre>
+## Roadmap & Timeframe   
+- Scoping
+- Prototyping/validating
+- Development
+- Release prep (documentaiton, marketing etc.)
+- Release
+- Retrospective
+</pre>
+</details>
 
-## Kick-off meeting
+<details>
+<summary>Success Metrics</summary>
+<pre>
+## Measuring success 
+Measure: What is the measure?
+Current baseline: What is the baseline that we see today?
+Target: how do we want to see that move?
+Link: link to query on metabase
+</pre>
+</details>
 
-### Roadmap & Timeframe
-(Key milestones or phases and estimated dates. Consider including further scoping, discovery, and prototyping. Include as a minimum: planning, design, development, documentation, feedback, iteration and, marketing)
-
-### Success metrics
-(What we will judge outcomes of the project by)
-
-### Risks
-<!-- If this project is going to go wrong, what's the mostly likely cause and what can you do to rerisk up front? -->
-
+<details>
+<summary>Risks</summary>
+<pre>
+## Risks
+If this project is going to go wrong, what's the most likely cause and what can you do to derisk upfront?
 - Risk:
 - Mitigation:
+</pre>
+</details>
 
-### Release planning
-
-**Estimated delivery date**
-
+<details>
+<summary>Documentation & Release</summary>
+<pre>
+## Documentation & Release Brief
+**Estimated delivery date: **
 - Which aspect(s) of the platform does this change impact?
 - Which group(s) of users will benefit from this change?
 - Is this project in response to a user-requested feature? If so who requested it (link to feature request if available)?
 - Is this project related to any similar work we have done, or are planning on doing in the next three months?
+</pre>
+</details>
 
-### Next steps
+<details>
+<summary>Next Steps</summary>
+<pre>
+## Next up
+- Create a project board, add this issue to the description
+- Open up any issues to decompartmentalise the project, add them to the project board
+- Open a documentation issue, add it to the documentation project board, reference this issue. 
+above 
+</pre>
+</details>
 
-- [ ] Open up any appropriate project issues
-- [ ] Open a documentation issue, link it to this one
-- [ ] Open a release issue, link it to this one
-- [ ] Create a project board, add this issue to the description, add any issues created above 
-
-## Project Closure
-
+<details>
+<summary>Closing this Issue</summary>
+<pre>
 - Close all relevant project issues
 - Open up issues for improvements 
-- Post comm's according to comm's plan (most likely in release issue)
-- Post project screencast on documentation slack channel 
-- Post project closure in newsletter slack channel 
+- Post comm's according to comm's plan
+- Post project screencast on #documentation slack channel 
+- Post project closure in #newsletter slack channel 
 - Celebrate!! 
+</pre>
+</details>


### PR DESCRIPTION
As per the discussion today this change _vastly_ reduced the overhead of creating a project issue.

I've moved a lot of the previous detail into a templates section at the end of the template `<xzibit gif/>`. the idea being that this is a more open template with minimum guidance that can be followed in the first instance and built up from there if need. 

[Diff view over here](https://github.com/opencollective/opencollective/pull/4580/commits/abbbf13fc262c47574c22b8169cc73f459133fa2?short_path=78999fc#diff-78999fcbbb99da4a9ee00336a4f8c2c90f00870b236700e583cd09cacb9c5de1)